### PR TITLE
ツイート時の URL エンコードを修正

### DIFF
--- a/src/lambda/handlers/get_ranking/index.ts
+++ b/src/lambda/handlers/get_ranking/index.ts
@@ -172,7 +172,7 @@ const checkRankingChange = async (
       '',
       `https://www.mchel.net/info#athletic:ranking:${encodeURIComponent(
         athleticInfo.name,
-      )}`,
+      ).replace(/[!'()*]/g, c => '%' + c.charCodeAt(0).toString(16))}`,
     ].join('\n'),
   );
 };

--- a/src/lambda/handlers/get_ranking/index.ts
+++ b/src/lambda/handlers/get_ranking/index.ts
@@ -172,7 +172,7 @@ const checkRankingChange = async (
       '',
       `https://www.mchel.net/info#athletic:ranking:${encodeURIComponent(
         athleticInfo.name,
-      ).replace(/[!'()*]/g, c => '%' + c.charCodeAt(0).toString(16))}`,
+      ).replace(/[!'()*.,]/g, c => '%' + c.charCodeAt(0).toString(16))}`,
     ].join('\n'),
   );
 };


### PR DESCRIPTION
Twitter の仕様に合わせ、`!'()*.,` を置換するようにしました。

ref: https://twitter.com/cn_ath_ta_rank/status/1495384522677837828 https://twitter.com/cn_ath_ta_rank/status/1495699944237572099